### PR TITLE
Merge rate limit test 

### DIFF
--- a/rest_VariantValidator/endpoints/hello.py
+++ b/rest_VariantValidator/endpoints/hello.py
@@ -1,5 +1,6 @@
 from flask_restx import Namespace, Resource
 from rest_VariantValidator.utils import request_parser, representations, exceptions
+from rest_VariantValidator.utils.limiter import limiter
 from flask import abort
 
 # Import VariantValidator  code
@@ -58,6 +59,13 @@ class HelloClass(Resource):
                  "status": "hello_world",
                  "metadata": config_dict
             }
+
+@api.route('/limit')
+class LimitedRateHelllo(Resource):
+    @limiter.limit("1/second")
+    @api.expect(parser, validate=True)
+    def get(self):
+        return { "status": "not yet hitting the rate limit" }
 
 
 @api.route('/trigger_error/<int:error_code>')

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -1,0 +1,51 @@
+"""Tests for the rate limiting code
+Currently limited to just testing that it works and keeps to the requested time.
+This code relies on the /hello/limit endpoint and relies on it's 1 access per-
+second limit.
+"""
+# Import necessary packages
+import time
+import pytest
+from flask import g
+from rest_VariantValidator.utils.limiter import limiter
+from rest_VariantValidator.app import application  # Import your Flask app
+
+# Fixture to set up the test client
+@pytest.fixture(scope='module',name='client')
+def rate_limit_test_client():
+    "Return a test client that works for rate limiting"
+    application.testing = False
+    application.debug = False
+    application.config['PROPAGATE_EXCEPTIONS'] = True
+    # This is fragile, and previous workarounds have failed before, so may
+    # break on updates to the limiter or flask test client code.
+    with application.app_context():
+        setattr(g, '%s_rate_limiting_complete' % limiter._key_prefix, False)
+    return application.test_client()  # Create a test client to interact with the app
+
+
+# test the limiter works as intended,
+def test_limit_endpoint_error_immediate(client):
+    "Provoke a limiter error by repeated requests to a limited endpoint"
+    response = client.get('/hello/limit', headers={'Content-Type': 'application/json'})
+    response = client.get('/hello/limit', headers={'Content-Type': 'application/json'})
+    assert response.status_code == 429
+    assert response.json["message"] == "Rate limit hit for this endpoint: See the endpoint documentation at https://rest.variantvalidator.org"
+
+def test_limit_endpoint_error_delayed(client):
+    """
+    Provoke a limiter error by repeated requests to a limited endpoint,
+    but with a partial (sub 1 second) delay.
+    """
+    response = client.get('/hello/limit', headers={'Content-Type': 'application/json'})
+    time.sleep(0.5)
+    response = client.get('/hello/limit', headers={'Content-Type': 'application/json'})
+    assert response.status_code == 429
+    assert response.json["message"] == "Rate limit hit for this endpoint: See the endpoint documentation at https://rest.variantvalidator.org"
+
+def test_limit_endpoint_success(client):
+    "Repeat the same as above, but with a 1 second delay to exceed limit"
+    response = client.get('/hello/limit', headers={'Content-Type': 'application/json'})
+    time.sleep(1)
+    response = client.get('/hello/limit', headers={'Content-Type': 'application/json'})
+    assert response.status_code == 200


### PR DESCRIPTION
This branch contains the rate Limit test patches.  The method of enabling this is hackey, and may have to change in the future, but is currently the only suggestion for fixing this that I could find.

@Peter-J-Freeman I am seeing some extra failures in the tests that should not have anything to do with my changes but are associated with the rate limiting code, namely that, despite the fact that we should not even be able to get rate limiting errors, we get 429 error codes for some (but not all) of the test_vv_endpoint_* tests from `test_endpoints.py`, sometimes along with some other test_vv_* tests.  Do you get these failures on your machine? if so I can push a short delay to these tests to prevent this, before you OK this PR.