### PR TITLE
Concurrency limit for testing/review/improvement

### DIFF
--- a/rest_VariantValidator/endpoints/hello.py
+++ b/rest_VariantValidator/endpoints/hello.py
@@ -1,6 +1,7 @@
+import time
 from flask_restx import Namespace, Resource
 from rest_VariantValidator.utils import request_parser, representations, exceptions
-from rest_VariantValidator.utils.limiter import limiter
+from rest_VariantValidator.utils.limiter import limiter, concurrency_limit
 from flask import abort
 
 # Import VariantValidator  code
@@ -66,6 +67,16 @@ class LimitedRateHelllo(Resource):
     @api.expect(parser, validate=True)
     def get(self):
         return { "status": "not yet hitting the rate limit" }
+
+@api.route('/limit_concurrent')
+class LimitedConcurrencyHelllo(Resource):
+    @limiter.limit("1/second")
+    @concurrency_limit()
+    @api.expect(parser, validate=True)
+    def get(self):
+        time.sleep(2)
+        return { "status": "not yet hitting the concurrency limit" }
+
 
 
 @api.route('/trigger_error/<int:error_code>')

--- a/rest_VariantValidator/endpoints/lovd_endpoints.py
+++ b/rest_VariantValidator/endpoints/lovd_endpoints.py
@@ -3,7 +3,7 @@ import ast
 from flask_restx import Namespace, Resource
 from rest_VariantValidator.utils import request_parser, representations, input_formatting
 from rest_VariantValidator.utils.object_pool import simple_variant_formatter_pool
-from rest_VariantValidator.utils.limiter import limiter
+from rest_VariantValidator.utils.limiter import limiter, concurrency_limit
 # get login authentication, if needed, or dummy auth if not present
 try:
     from VariantValidator_APIs.db_auth.verify_password import auth
@@ -71,6 +71,7 @@ class LOVDClass(Resource):
     @api.expect(parser, validate=True)
     @auth.login_required()
     @limiter.limit("4/second")
+    @concurrency_limit()
     def get(self, genome_build, variant_description, transcript_model, select_transcripts, checkonly, liftover):
         if transcript_model == 'None' or transcript_model == 'none':
             transcript_model = None

--- a/rest_VariantValidator/endpoints/variantformatter_endpoints.py
+++ b/rest_VariantValidator/endpoints/variantformatter_endpoints.py
@@ -2,7 +2,7 @@
 from flask_restx import Namespace, Resource
 from rest_VariantValidator.utils import request_parser, representations, input_formatting
 from rest_VariantValidator.utils.object_pool import simple_variant_formatter_pool
-from rest_VariantValidator.utils.limiter import limiter
+from rest_VariantValidator.utils.limiter import limiter, concurrency_limit
 # get login authentication, if needed, or dummy auth if not present
 try:
     from VariantValidator_APIs.db_auth.verify_password import auth
@@ -55,6 +55,7 @@ class VariantFormatterClass(Resource):
     @api.expect(parser, validate=True)
     @auth.login_required()
     @limiter.limit("4/second")
+    @concurrency_limit()
     def get(self, genome_build, variant_description, transcript_model, select_transcripts, checkonly):
         if transcript_model == 'None' or transcript_model == 'none':
             transcript_model = None

--- a/rest_VariantValidator/endpoints/variantvalidator_endpoints.py
+++ b/rest_VariantValidator/endpoints/variantvalidator_endpoints.py
@@ -2,7 +2,7 @@
 from flask_restx import Namespace, Resource
 from rest_VariantValidator.utils import exceptions, request_parser, representations, input_formatting
 from rest_VariantValidator.utils.object_pool import vval_object_pool, g2t_object_pool
-from rest_VariantValidator.utils.limiter import limiter
+from rest_VariantValidator.utils.limiter import limiter, concurrency_limit
 # get login authentication, if needed, or dummy auth if not present
 try:
     from VariantValidator_APIs.db_auth.verify_password import auth
@@ -58,6 +58,7 @@ class VariantValidatorClass(Resource):
     @api.expect(parser, validate=True)
     @auth.login_required()
     @limiter.limit("2/second")
+    @concurrency_limit()
     def get(self, genome_build, variant_description, select_transcripts):
 
         # Import object from vval pool
@@ -150,6 +151,7 @@ class VariantValidatorEnsemblClass(Resource):
     @api.expect(parser, validate=True)
     @auth.login_required()
     @limiter.limit("2/second")
+    @concurrency_limit()
     def get(self, genome_build, variant_description, select_transcripts):
 
         # Import object from vval pool
@@ -220,6 +222,7 @@ class Gene2transcriptsClass(Resource):
     @api.expect(parser, validate=True)
     @auth.login_required()
     @limiter.limit("1/second")
+    @concurrency_limit()
     def get(self, gene_query):
 
         # Get vvval object from pool
@@ -283,6 +286,7 @@ class Gene2transcriptsV2Class(Resource):
     @api.expect(parser, validate=True)
     @auth.login_required()
     @limiter.limit("1/second")
+    @concurrency_limit()
     def get(self, gene_query, limit_transcripts, transcript_set, genome_build):
 
         # Get vval object from pool
@@ -334,6 +338,7 @@ class Hgvs2referenceClass(Resource):
     @api.expect(parser, validate=True)
     @auth.login_required()
     @limiter.limit("4/second")
+    @concurrency_limit()
     def get(self, hgvs_description):
 
         # Get vval object from pool

--- a/rest_VariantValidator/utils/limiter.py
+++ b/rest_VariantValidator/utils/limiter.py
@@ -1,7 +1,36 @@
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from flask import request
 
 limiter = Limiter(key_func=get_remote_address)
+
+_running_vals = {}
+def concurrency_limit():
+    """Wrapper for decorating in order to stop parallel requests
+
+    Currently relies on the IP we will need to change this if we
+    want to do limits per login. "_running_vals" should only bloat if
+    we get hard crashes.
+    """
+    def decorator(handler):
+        def wrapper(*args, **kwargs):
+            """
+            Store the IP address source of running validations, if a user is
+            already running a validation block use until finished, remove
+            stored IP before returning.
+            """
+            ip_address = request.remote_addr
+            if ip_address in _running_vals:
+                err = 'Concurrency limit exceeded. Please try again once " + \
+                        "your existing API requests have completed.'
+                return {"message":err }, 429
+
+            _running_vals[ip_address] = 1
+            result = handler(*args, **kwargs)
+            del _running_vals[ip_address]
+            return result
+        return wrapper
+    return decorator
 
 # <LICENSE>
 # Copyright (C) 2016-2024 VariantValidator Contributors

--- a/tests/test_limiters.py
+++ b/tests/test_limiters.py
@@ -1,11 +1,14 @@
-"""Tests for the rate limiting code
-Currently limited to just testing that it works and keeps to the requested time.
+"""Tests for the usage limiting code, for both rate and concurrency
+Currently rate limit code is limited to just testing that it works and keeps to
+the requested time.
 This code relies on the /hello/limit endpoint and relies on it's 1 access per-
-second limit.
+second limit to test the rate limiting code, and the /hello/limit_concurrent test
+to test the concurrency limit.
 """
 
 # Import necessary packages
 import time
+import threading
 import pytest
 from flask import g
 from rest_VariantValidator.utils.limiter import limiter
@@ -53,3 +56,70 @@ def test_limit_endpoint_success(client):
     response = client.get('/hello/limit', headers={'Content-Type': 'application/json'})
     assert response.status_code == 200
 
+# Test the concurrency limiter
+# This set of tests use threading so timings are not 100%. The limit_concurrent
+# endpoint takes 2 seconds to run, when it works, unsuccessful attempts due to
+# concurrency will count towards the rate limit, but rate limit failures do not.
+def test_concurrency_limit_endpoint_error_immediate(client):
+    """Test that immediate repeated requests provoke the normal rate limit first"""
+    def test_concurrent(client):
+        response = client.get('/hello/limit_concurrent', headers={'Content-Type': 'application/json'})
+    thread = threading.Thread(target=test_concurrent, args=(client,))
+    thread.start()
+    time.sleep(0.1)
+    response = client.get('/hello/limit_concurrent', headers={'Content-Type': 'application/json'})
+    assert response.status_code == 429
+    assert response.json["message"] == "Rate limit hit for this endpoint: See the endpoint documentation at https://rest.variantvalidator.org"
+    thread.join()
+    time.sleep(0.9)
+
+def test_concurrency_limit_endpoint_error_delayed_small(client):
+    """
+    Provoke a concurrency limiter error by repeated requests to a limited endpoint,
+    with a delay long enough to pass the input rate limit.
+    """
+    def test_concurrent(client):
+        print("testing")
+        response = client.get('/hello/limit_concurrent', headers={'Content-Type': 'application/json'})
+    thread = threading.Thread(target=test_concurrent, args=(client,))
+    thread.start()
+    time.sleep(1.1)
+    response = client.get('/hello/limit_concurrent', headers={'Content-Type': 'application/json'})
+    assert response.status_code == 429
+    assert response.json["message"].startswith('Concurrency limit exceeded. ')
+    thread.join()
+    time.sleep(1)
+
+def test_concurrency_limit_endpoint_error_delayed_long(client):
+    """
+    Provoke a concurrency limiter error by repeated requests to a limited endpoint,
+    with a longer delay, long enough to pass the input rate limit and nearly pass the
+    concurrency limit for the 2s sleeping test endpoint.
+    """
+    def test_concurrent(client):
+        print("testing")
+        response = client.get('/hello/limit_concurrent', headers={'Content-Type': 'application/json'})
+    thread = threading.Thread(target=test_concurrent, args=(client,))
+    thread.start()
+    time.sleep(1.9)
+    response = client.get('/hello/limit_concurrent', headers={'Content-Type': 'application/json'})
+    assert response.status_code == 429
+    assert response.json["message"].startswith('Concurrency limit exceeded. ')
+    thread.join()
+    time.sleep(1)
+
+def test_concurrency_limit_endpoint_success(client):
+    """
+    Repeat the same as above, but with a 5 second delay to allow return and exceed
+    the concurrency limit
+    """
+    def test_concurrent(client):
+        print("testing")
+        response = client.get('/hello/limit_concurrent', headers={'Content-Type': 'application/json'})
+    thread = threading.Thread(target=test_concurrent, args=(client,))
+    thread.start()
+    time.sleep(2.1)
+    response = client.get('/hello/limit_concurrent', headers={'Content-Type': 'application/json'})
+    assert response.status_code == 200
+    thread.join()
+    time.sleep(1)


### PR DESCRIPTION
This pull request contains the in progress state of the concurrency limiter, which at current prevents individual users from submitting multiple concurrent requests, requiring users to wait until the first request has finished before submitting a new one. This should make it a lot harder for individual uses to (unintentionally) push over the server by themselves with multiple long running requests.

@Peter-J-Freeman Please could you have a look at this test it out and tell me what you think. This is the simplest design, but totally banning concurrent requests from a single user is strict, no matter how much it simplifies things.