### PR TITLE
Flask env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ build
 dist
 rest_VariantValidator.egg-info
 .DS_Store
-
-
+__pycache__

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -56,5 +56,19 @@ CustomLog /local/apache2/log/access_log for_pound
 
 ```
 
+## Flask configuration
+
+rest_variantValidator is a Flask application. Flask can be
+[configured](https://flask.palletsprojects.com/en/stable/config/)
+using its
+[prefixed environment variable](https://flask.palletsprojects.com/en/stable/config/#configuring-from-environment-variables)
+configuration mechanism, so documented settings can be set with a prefix 
+of `FLASK_`.
+
+This mechanism is also used for Flask extensions such as the
+[Flask-Limiter](https://github.com/alisaifee/flask-limiter/tree/master)
+rate limiter this uses, which can be disabled by setting 
+`FLASK_RATELIMIT_ENABLED=`.
+
 ## Additional resources
 We are compiling a number of jupyter notebook user guides for rest_variantValidator in [rest_variantValidator_manuals](https://github.com/openvar/rest_variantValidator_manuals)

--- a/rest_VariantValidator/app.py
+++ b/rest_VariantValidator/app.py
@@ -51,6 +51,7 @@ parser = request_parser.parser
 
 # Define the application as a Flask app with the name defined by __name__
 application = Flask(__name__)
+application.config.from_prefixed_env()
 
 # Create a limiter instance and attach it to your Flask application
 limiter.init_app(application)


### PR DESCRIPTION
Add code from Genomenon that allows flask to load config from environment variables as standard, this can be used to disable the rate limits for endpoints if wanted (e.g if running on internal servers). (see https://github.com/openvar/rest_variantValidator/issues/192)

This may be replaced/supplemented later with VV endpoint specific config options.